### PR TITLE
fix: 🐛 initialize logging in game server and subprocess games

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,9 @@ COPY unipress ./unipress
 COPY main.py README.md pyproject.toml uv.lock ./
 COPY high_scores.json ./high_scores.json
 
+# Create logs directory with proper permissions
+RUN mkdir -p logs && chown 1000:1000 logs
+
 # Note: No user creation - container will run as UID 1000:1000 from docker-compose
 
 ENV PATH="/app/.venv/bin:${PATH}" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     network_mode: host
     volumes:
       - ./high_scores.json:/app/high_scores.json
+      - ./logs:/app/logs
       - /tmp/.X11-unix:/tmp/.X11-unix:ro
       # Audio volumes for PipeWire/PulseAudio
       - ${XDG_RUNTIME_DIR}/pulse:${XDG_RUNTIME_DIR}/pulse

--- a/unipress/core/game_server.py
+++ b/unipress/core/game_server.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, Optional
 
 from flask import Flask, jsonify, request
 
-from unipress.core.logger import get_logger, log_error, log_game_event
+from unipress.core.logger import get_logger, init_logger, log_error, log_game_event
 
 app = Flask(__name__)
 logger = get_logger("game_server")
@@ -147,6 +147,9 @@ def list_games() -> Dict[str, Any]:
 
 def main() -> None:
     """Start the game server."""
+    # Initialize logger first
+    init_logger("game_server")
+    
     logger.info("Starting Unipress Game Server")
     
     # Run Flask app

--- a/unipress/games/jumper/game.py
+++ b/unipress/games/jumper/game.py
@@ -562,6 +562,10 @@ class JumperGame(BaseGame):
 # Test runner for development
 if __name__ == "__main__":
     import sys
+    from unipress.core.logger import init_logger
+    
+    # Initialize logging for the game process
+    init_logger("jumper")
     
     difficulty = 5
     if len(sys.argv) > 1:


### PR DESCRIPTION
- Add init_logger() call in game_server.py main() function
- Add logger initialization to jumper game __main__ section
- Mount ./logs:/app/logs volume in docker-compose for log persistence
- Create logs directory with proper permissions in Dockerfile
- Ensures all game events and player actions are properly logged in containers

## Description
Brief description of changes

## Type of Change
- [ ] 🎸 New feature
- [ ] 🐛 Bug fix
- [ ] ✏️ Documentation
- [ ] 🤖 Build/tool changes
- [ ] 💡 Refactoring
- [ ] 💍 Tests
- [ ] 💄 Style changes
- [ ] ⚡ Performance improvements
- [ ] 🏹 Release
- [ ] 🎡 CI/CD changes

## Testing
- [ ] All tests pass (`uv run pytest`)
- [ ] Linting passes (`uv run ruff check`)
- [ ] Code is formatted (`uv run ruff format`)
- [ ] Type checking passes (`uv run mypy unipress`)

## Checklist
- [ ] Code follows project standards
- [ ] Self-review completed
- [ ] Conventional commits used
- [ ] No unrelated changes bundled
- [ ] Documentation updated if needed

## Screenshots (if applicable)
Add screenshots for UI changes
